### PR TITLE
Add cache age to bundle and deploy br bundle

### DIFF
--- a/deploy/s3.js
+++ b/deploy/s3.js
@@ -28,7 +28,8 @@ const uploadToS3 = async (
   fileBody,
   fileType = "",
   encoding = "",
-  ACL = ""
+  ACL = "",
+  cacheAge = "300"
 ) => {
   // Upload file to bucket
   try {
@@ -39,6 +40,7 @@ const uploadToS3 = async (
         Body: fileBody,
         ContentType: fileType,
         ContentEncoding: encoding,
+        CacheControl: `max-age=${cacheAge}`,
         ACL: ACL,
       })
     );

--- a/deploy/upload-build.js
+++ b/deploy/upload-build.js
@@ -2,7 +2,7 @@ const s3 = require("../deploy/s3.js");
 const fs = require("fs");
 const path = require("path");
 
-const uploadBuild = async (file, encoding = "") => {
+const uploadBuild = async (file, encoding = "", cacheAge = "300") => {
   await s3.createBucket();
   const buildFile = fs.createReadStream(file);
   buildFile.on("error", (err) => {
@@ -15,15 +15,26 @@ const uploadBuild = async (file, encoding = "") => {
     buildFile,
     "text/javascript",
     encoding,
-    "public-read"
+    "public-read",
+    cacheAge
   );
 };
 
 const run = async () => {
-  await uploadBuild(path.join(__dirname, "../public/checkout_bundle.js"));
+  await uploadBuild(
+    path.join(__dirname, "../public/checkout_bundle.js"),
+    "",
+    "31536000"
+  );
   await uploadBuild(
     path.join(__dirname, "../public/checkout_bundle.js.gz"),
-    "gzip"
+    "gzip",
+    "31536000"
+  );
+  await uploadBuild(
+    path.join(__dirname, "../public/checkout_bundle.js.br"),
+    "br",
+    "31536000"
   );
   process.exit;
 };


### PR DESCRIPTION
Refactored bundle deployment script to add cache age to bundle files to improve site return visit performance and deployed brotli compressed bundle to further reduce bundle size in client request.